### PR TITLE
Add Discord Notifications for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,36 @@ jobs:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
     steps:
+      # 1. Checkout code
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # 2. Set up Python
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.10.6'
 
+      # 3. Install dependencies
       - name: Install dependencies
         run: make build
 
+      # 4. Run tests
       - name: Run tests
         run: make test
 
-      # Discord notification on failure
+      # 5. Discord notification on failure
       - name: Notify Discord on failure
         if: failure()
         run: |
           curl -H "Content-Type: application/json" \
-               -d '{"content": "⚠️ CI Failed on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'", "username": "GitHub Actions"}' \
+               -d '{"content": "⚠️ CI Failed on branch '${GITHUB_REF_NAME}'", "sender": "GitHub Actions"}' \
                $DISCORD_WEBHOOK_URL
 
-      # Discord notification on success
+      # 6. Discord notification on success
       - name: Notify Discord on success
         if: success()
         run: |
           curl -H "Content-Type: application/json" \
-               -d '{"content": "✅ CI Succeeded on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'", "username": "GitHub Actions"}' \
+               -d '{"content": "✅ CI Succeeded on branch '${GITHUB_REF_NAME}'", "sender": "GitHub Actions"}' \
                $DISCORD_WEBHOOK_URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
-name: CI
+name: CI Pipeline
 
 on:
   push:
-    branches: [ Prod ]
   pull_request:
-    branches: [ Prod ]
 
 jobs:
   build-test-lint:
@@ -36,7 +34,7 @@ jobs:
         if: failure()
         run: |
           curl -H "Content-Type: application/json" \
-               -d '{"content": "⚠️ CI Failed on branch '${GITHUB_REF_NAME}'", "sender": "GitHub Actions"}' \
+               -d "{\"content\": \"⚠️ **CI Failed** on branch **${GITHUB_REF_NAME}** by **${{ github.actor }}** → [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\"}" \
                $DISCORD_WEBHOOK_URL
 
       # 6. Discord notification on success
@@ -44,5 +42,5 @@ jobs:
         if: success()
         run: |
           curl -H "Content-Type: application/json" \
-               -d '{"content": "✅ CI Succeeded on branch '${GITHUB_REF_NAME}'", "sender": "GitHub Actions"}' \
+               -d "{\"content\": \"✅ **CI Succeeded** on branch **${GITHUB_REF_NAME}** by **${{ github.actor }}** → [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\"}" \
                $DISCORD_WEBHOOK_URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-test-lint:
     runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
     steps:
       - name: Checkout code
@@ -24,3 +26,19 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      # Discord notification on failure
+      - name: Notify Discord on failure
+        if: failure()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -d '{"content": "⚠️ CI Failed on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'"}' \
+               $DISCORD_WEBHOOK_URL
+
+      # Discord notification on success
+      - name: Notify Discord on success
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -d '{"content": "✅ CI Succeeded on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'"}' \
+               $DISCORD_WEBHOOK_URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         if: failure()
         run: |
           curl -H "Content-Type: application/json" \
-               -d '{"content": "⚠️ CI Failed on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'"}' \
+               -d '{"content": "⚠️ CI Failed on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'", "username": "GitHub Actions"}' \
                $DISCORD_WEBHOOK_URL
 
       # Discord notification on success
@@ -40,5 +40,5 @@ jobs:
         if: success()
         run: |
           curl -H "Content-Type: application/json" \
-               -d '{"content": "✅ CI Succeeded on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'"}' \
+               -d '{"content": "✅ CI Succeeded on branch '${GITHUB_REF_NAME}'! Commit: '${GITHUB_SHA}'", "username": "GitHub Actions"}' \
                $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
Enhance the existing CI/CD pipeline to send real-time notifications to a Discord channel whenever the workflow succeeds or fails. This ensures the team is immediately aware of the build status.