### PR TITLE
Implement crop modal UI and notes popup; add full CRUD test coverage for crops

### DIFF
--- a/app/backend/crop/crop.py
+++ b/app/backend/crop/crop.py
@@ -2,9 +2,11 @@ from django.contrib.auth.decorators import login_required
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import get_object_or_404, redirect, render
 
-from app.exceptions.crop.exception import (CropCreationException,
-                                           CropDeleteException,
-                                           CropEditException)
+from app.exceptions.crop.exception import (
+    CropCreationException,
+    CropDeleteException,
+    CropEditException,
+)
 from app.logging.logging import Logger
 
 from ..models import Crop
@@ -35,7 +37,6 @@ def crop_list(request):
 def add_crop(request):
     if request.method == "POST":
         try:
-
             name = request.POST.get("name")
             crop_type = request.POST.get("crop_type")
             planting_date = request.POST.get("planting_date")
@@ -47,9 +48,10 @@ def add_crop(request):
             region = request.POST.get("region")
             notes = request.POST.get("notes")
 
-            if not name or not crop_type or not planting_date or not expected_yield:
+            # REQUIRED FIELDS (aligned with ticket)
+            if not name or not crop_type or not planting_date:
                 raise CropCreationException(
-                    "Name, crop type, planting date, and expected yield are required."
+                    "Name, crop type, and planting date are required."
                 )
 
             crop = Crop.objects.create(
@@ -59,9 +61,7 @@ def add_crop(request):
                 harvest_date=harvest_date if harvest_date else None,
                 expected_yield=float(expected_yield) if expected_yield else 0,
                 yield_efficiency=float(yield_efficiency) if yield_efficiency else 0,
-                water_usage_liters=(
-                    float(water_usage_liters) if water_usage_liters else 0
-                ),
+                water_usage_liters=float(water_usage_liters) if water_usage_liters else 0,
                 next_checkup=next_checkup if next_checkup else None,
                 region=region,
                 notes=notes,
@@ -82,6 +82,7 @@ def add_crop(request):
                 "app/crop_list.html",
                 {"crops": crops, "error": str(e)},
             )
+
         except ValueError as e:
             logger.log(f"Value error during crop creation by {request.user}: {e}")
 
@@ -97,6 +98,7 @@ def add_crop(request):
                     "error": "Invalid input values. Please check numeric fields.",
                 },
             )
+
         except Exception as e:
             logger.log(f"Unexpected error during crop creation: {e}")
 
@@ -138,18 +140,17 @@ def edit_crop(request):
             crop.region = request.POST.get("region")
             crop.notes = request.POST.get("notes")
 
+            # REQUIRED FIELDS (aligned with ticket)
             if not crop.name or not crop.crop_type or not crop.planting_date:
                 raise CropEditException(
                     "Name, crop type, and planting date are required."
                 )
 
+            # NUMERIC FIELDS: allow blank -> 0; invalid -> error
             try:
-                if crop.expected_yield:
-                    crop.expected_yield = float(crop.expected_yield)
-                if crop.yield_efficiency:
-                    crop.yield_efficiency = float(crop.yield_efficiency)
-                if crop.water_usage_liters:
-                    crop.water_usage_liters = float(crop.water_usage_liters)
+                crop.expected_yield = float(crop.expected_yield) if crop.expected_yield else 0
+                crop.yield_efficiency = float(crop.yield_efficiency) if crop.yield_efficiency else 0
+                crop.water_usage_liters = float(crop.water_usage_liters) if crop.water_usage_liters else 0
             except ValueError:
                 raise CropEditException(
                     "Invalid numeric values in yield or water usage fields."
@@ -174,6 +175,7 @@ def edit_crop(request):
                 "app/crop_list.html",
                 {"crops": crops, "error": str(e)},
             )
+
         except Exception as e:
             logger.log(f"Unexpected error during crop edit: {e}")
 
@@ -189,6 +191,8 @@ def edit_crop(request):
                     "error": "An unexpected error occurred while editing the crop.",
                 },
             )
+
+    return redirect("crop_list")
 
 
 @login_required
@@ -218,6 +222,7 @@ def delete_crop(request):
                 "app/crop_list.html",
                 {"crops": crops, "error": str(e)},
             )
+
         except Exception as e:
             logger.log(f"Unexpected error during crop deletion: {e}")
 
@@ -233,3 +238,5 @@ def delete_crop(request):
                     "error": "An unexpected error occurred while deleting the crop.",
                 },
             )
+
+    return redirect("crop_list")

--- a/app/static/js/crop_list.js
+++ b/app/static/js/crop_list.js
@@ -2,35 +2,65 @@ const addButton = document.getElementById("addButton");
 const popupForm = document.getElementById("popupForm");
 const closeButton = document.getElementById("closeButton");
 
-
 addButton.addEventListener("click", () => {
-    popupForm.classList.remove("hidden");
+  popupForm.classList.remove("hidden");
 });
 
 closeButton.addEventListener("click", () => {
-    popupForm.classList.add("hidden");
+  popupForm.classList.add("hidden");
 });
 
+// Notes popup logic (matches Supplies pattern)
+const notesPopup = document.getElementById("notesPopup");
+const closeNotesButton = document.getElementById("closeNotesButton");
+const outputNotes = document.getElementById("notesOfCropOutput");
+
+closeNotesButton.addEventListener("click", () => {
+  notesPopup.classList.add("hidden");
+});
+
+function openNotesPopup(notesToShow) {
+  outputNotes.value = notesToShow ? `${notesToShow}` : "—";
+  notesPopup.classList.remove("hidden");
+}
+
+// Edit Popup Logic
 const editPopup = document.getElementById("editPopup");
 const closeEditButton = document.getElementById("closeEditButton");
 
-function openEditPopup(id, name, crop_type, planting, harvest, yieldValue, yieldEfficiency, waterUsage, nextCheckup, region, notes) {
-    document.getElementById("editId").value = id;
-    document.getElementById("editName").value = name;
-    document.getElementById("editCropType").value = crop_type;
-    document.getElementById("editPlantingDate").value = planting;
-    document.getElementById("editHarvestDate").value = harvest;
-    document.getElementById("editExpectedYield").value = yieldValue;
-    document.getElementById("editYieldEfficiency").value = yieldEfficiency;
-    document.getElementById("editWaterUsageLiters").value = waterUsage;
-    document.getElementById("editNextCheckup").value = nextCheckup;
-    document.getElementById("editRegion").value = region;
-    document.getElementById("editNotes").value = notes;
-    editPopup.classList.remove("hidden");
+function openEditPopup(
+  id,
+  name,
+  crop_type,
+  planting,
+  harvest,
+  yieldValue,
+  yieldEfficiency,
+  waterUsage,
+  nextCheckup,
+  region,
+  notes
+) {
+  document.getElementById("editId").value = id;
+  document.getElementById("editName").value = name;
+  document.getElementById("editCropType").value = crop_type;
+  document.getElementById("editPlantingDate").value = planting;
+
+  // Avoid "null" in date inputs
+  document.getElementById("editHarvestDate").value = harvest || "";
+  document.getElementById("editNextCheckup").value = nextCheckup || "";
+
+  document.getElementById("editExpectedYield").value = yieldValue || "";
+  document.getElementById("editYieldEfficiency").value = yieldEfficiency || "0";
+  document.getElementById("editWaterUsageLiters").value = waterUsage || "0";
+  document.getElementById("editRegion").value = region || "";
+  document.getElementById("editNotes").value = notes || "";
+
+  editPopup.classList.remove("hidden");
 }
 
 closeEditButton.addEventListener("click", () => {
-    editPopup.classList.add("hidden");
+  editPopup.classList.add("hidden");
 });
 
 // Delete Popup Logic
@@ -38,11 +68,11 @@ const deletePopup = document.getElementById("deletePopup");
 const closeDeleteButton = document.getElementById("closeDeleteButton");
 
 function openDeletePopup(id, name) {
-    document.getElementById("deleteId").value = id;
-    document.getElementById("deleteCropName").textContent = name;
-    deletePopup.classList.remove("hidden");
+  document.getElementById("deleteId").value = id;
+  document.getElementById("deleteCropName").textContent = name;
+  deletePopup.classList.remove("hidden");
 }
 
 closeDeleteButton.addEventListener("click", () => {
-    deletePopup.classList.add("hidden");
+  deletePopup.classList.add("hidden");
 });

--- a/app/templates/app/crop_list.html
+++ b/app/templates/app/crop_list.html
@@ -21,106 +21,162 @@
     Add Crop
 </button>
 
-<!-- Add Button Popup Form -->
+<!-- Add Popup -->
 <div id="popupForm" class="hidden fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-md">
+    <div class="bg-white p-6 rounded shadow-md w-full max-w-3xl">
         <h3 class="text-xl font-bold mb-4">Add Crop</h3>
         <form method="post" id="addCropForm" action="{% url 'add_crop' %}">
             {% csrf_token %}
-            <label class="block mb-2">Name:</label>
-            <input type="text" name="name" class="w-full border rounded px-3 py-2 mb-4" maxlength="100" required />
 
-            <label class="block mb-2">Crop Type:</label>
-            <input type="text" name="crop_type" class="w-full border rounded px-3 py-2 mb-4" maxlength="100" required />
+            <div class="flex space-x-2 justify-between w-full">
+                <div class="w-1/2">
+                    <label class="block mb-2">Name:</label>
+                    <input type="text" name="name" class="w-full border rounded px-3 py-2 mb-4" maxlength="100" required />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Crop Type:</label>
+                    <input type="text" name="crop_type" class="w-full border rounded px-3 py-2 mb-4" maxlength="100" required />
+                </div>
+            </div>
 
-            <label class="block mb-2">Planting Date:</label>
-            <input type="date" name="planting_date" class="w-full border rounded px-3 py-2 mb-4" required />
+            <div class="flex space-x-2 justify-between w-full">
+                <div class="w-1/2">
+                    <label class="block mb-2">Planting Date:</label>
+                    <input type="date" name="planting_date" class="w-full border rounded px-3 py-2 mb-4" required />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Harvest Date:</label>
+                    <input type="date" name="harvest_date" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+            </div>
 
-            <label class="block mb-2">Harvest Date:</label>
-            <input type="date" name="harvest_date" class="w-full border rounded px-3 py-2 mb-4" />
+            <div class="flex space-x-2 justify-between w-full">
+                <div class="w-1/2">
+                    <label class="block mb-2">Expected Yield:</label>
+                    <input type="number" step="0.01" name="expected_yield" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Yield Efficiency (%):</label>
+                    <input type="number" step="0.01" name="yield_efficiency" class="w-full border rounded px-3 py-2 mb-4" value="0" />
+                </div>
+            </div>
 
-            <label class="block mb-2">Expected Yield:</label>
-            <input type="number" step="0.01" name="expected_yield" class="w-full border rounded px-3 py-2 mb-4" required />
+            <div class="flex space-x-2 justify-between w-full">
+                <div class="w-1/2">
+                    <label class="block mb-2">Water Usage (Liters):</label>
+                    <input type="number" step="0.01" name="water_usage_liters" class="w-full border rounded px-3 py-2 mb-4" value="0" />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Next Checkup:</label>
+                    <input type="date" name="next_checkup" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+            </div>
 
-            <label class="block mb-2">Yield Efficiency (%):</label>
-            <input type="number" step="0.01" name="yield_efficiency" class="w-full border rounded px-3 py-2 mb-4" value="0" />
-
-            <label class="block mb-2">Water Usage (Liters):</label>
-            <input type="number" step="0.01" name="water_usage_liters" class="w-full border rounded px-3 py-2 mb-4" value="0" />
-
-            <label class="block mb-2">Next Checkup:</label>
-            <input type="date" name="next_checkup" class="w-full border rounded px-3 py-2 mb-4" />
-
-            <label class="block mb-2">Region:</label>
-            <input type="text" name="region" class="w-full border rounded px-3 py-2 mb-4" maxlength="50" />
+            <div class="flex space-x-2 justify-between w-full">
+                <div class="w-1/2">
+                    <label class="block mb-2">Region:</label>
+                    <input type="text" name="region" class="w-full border rounded px-3 py-2 mb-4" maxlength="50" />
+                </div>
+                <div class="w-1/2"></div>
+            </div>
 
             <label class="block mb-2">Notes:</label>
-            <textarea name="notes" class="w-full border rounded px-3 py-2 mb-4" rows="3"></textarea>
+            <textarea name="notes" class="w-full border rounded px-3 py-2 mb-4" rows="6"></textarea>
 
-            <button type="submit" class="text-white py-2 px-4 rounded hover:bg-green-700"
-                style="background-color: #335D43;">
-                Save
-            </button>
+            <div class="flex space-x-2 justify-between w-full">
+                <div>
+                    <button type="submit" class="text-white py-2 px-4 rounded hover:bg-green-700"
+                        style="background-color: #335D43;">
+                        Save
+                    </button>
+                </div>
+                <div>
+                    <button type="button" id="closeButton" class="bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400">
+                        Cancel
+                    </button>
+                </div>
+            </div>
         </form>
-        <button id="closeButton" class="mt-4 bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400">
-            Cancel
-        </button>
     </div>
 </div>
 
 <!-- Edit Popup -->
 <div id="editPopup" class="hidden fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-md">
+    <div class="bg-white p-6 rounded shadow-md w-full max-w-3xl">
         <h3 class="text-xl font-bold mb-4">Edit Crop</h3>
         <form method="post" id="editCropForm" action="{% url 'edit_crop' %}">
             {% csrf_token %}
             <input type="hidden" name="id" id="editId" />
-            <label class="block mb-2">Name:</label>
-            <input type="text" name="name" id="editName" class="w-full border rounded px-3 py-2 mb-4" maxlength="100"
-                required />
 
-            <label class="block mb-2">Crop Type:</label>
-            <input type="text" name="crop_type" id="editCropType" class="w-full border rounded px-3 py-2 mb-4" maxlength="100"
-                required />
+            <div class="w-full flex justify-between space-x-2">
+                <div class="w-1/2">
+                    <label class="block mb-2">Name:</label>
+                    <input type="text" name="name" id="editName" class="w-full border rounded px-3 py-2 mb-4" maxlength="100" required />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Crop Type:</label>
+                    <input type="text" name="crop_type" id="editCropType" class="w-full border rounded px-3 py-2 mb-4" maxlength="100" required />
+                </div>
+            </div>
 
-            <label class="block mb-2">Planting Date:</label>
-            <input type="date" name="planting_date" id="editPlantingDate" class="w-full border rounded px-3 py-2 mb-4"
-                required />
+            <div class="w-full flex justify-between space-x-2">
+                <div class="w-1/2">
+                    <label class="block mb-2">Planting Date:</label>
+                    <input type="date" name="planting_date" id="editPlantingDate" class="w-full border rounded px-3 py-2 mb-4" required />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Harvest Date:</label>
+                    <input type="date" name="harvest_date" id="editHarvestDate" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+            </div>
 
-            <label class="block mb-2">Harvest Date:</label>
-            <input type="date" name="harvest_date" id="editHarvestDate" class="w-full border rounded px-3 py-2 mb-4"
-                />
+            <div class="w-full flex justify-between space-x-2">
+                <div class="w-1/2">
+                    <label class="block mb-2">Expected Yield:</label>
+                    <input type="number" step="0.01" name="expected_yield" id="editExpectedYield" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Yield Efficiency (%):</label>
+                    <input type="number" step="0.01" name="yield_efficiency" id="editYieldEfficiency" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+            </div>
 
-            <label class="block mb-2">Expected Yield:</label>
-            <input type="number" step="0.01" name="expected_yield" id="editExpectedYield"
-                class="w-full border rounded px-3 py-2 mb-4" required />
+            <div class="w-full flex justify-between space-x-2">
+                <div class="w-1/2">
+                    <label class="block mb-2">Water Usage (Liters):</label>
+                    <input type="number" step="0.01" name="water_usage_liters" id="editWaterUsageLiters" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+                <div class="w-1/2">
+                    <label class="block mb-2">Next Checkup:</label>
+                    <input type="date" name="next_checkup" id="editNextCheckup" class="w-full border rounded px-3 py-2 mb-4" />
+                </div>
+            </div>
 
-            <label class="block mb-2">Yield Efficiency (%):</label>
-            <input type="number" step="0.01" name="yield_efficiency" id="editYieldEfficiency"
-                class="w-full border rounded px-3 py-2 mb-4" />
-
-            <label class="block mb-2">Water Usage (Liters):</label>
-            <input type="number" step="0.01" name="water_usage_liters" id="editWaterUsageLiters"
-                class="w-full border rounded px-3 py-2 mb-4" />
-
-            <label class="block mb-2">Next Checkup:</label>
-            <input type="date" name="next_checkup" id="editNextCheckup" class="w-full border rounded px-3 py-2 mb-4"
-                />
-
-            <label class="block mb-2">Region:</label>
-            <input type="text" name="region" id="editRegion" class="w-full border rounded px-3 py-2 mb-4" maxlength="50" />
+            <div class="w-full flex justify-between space-x-2">
+                <div class="w-1/2">
+                    <label class="block mb-2">Region:</label>
+                    <input type="text" name="region" id="editRegion" class="w-full border rounded px-3 py-2 mb-4" maxlength="50" />
+                </div>
+                <div class="w-1/2"></div>
+            </div>
 
             <label class="block mb-2">Notes:</label>
-            <textarea name="notes" id="editNotes" class="w-full border rounded px-3 py-2 mb-4" rows="3"></textarea>
+            <textarea name="notes" id="editNotes" class="w-full border rounded px-3 py-2 mb-4" rows="6"></textarea>
 
-            <button type="submit" class="text-white py-2 px-4 rounded hover:bg-green-700"
-                style="background-color: #335D43;">
-                Save Changes
-            </button>
+            <div class="w-full flex justify-between space-x-2">
+                <div>
+                    <button type="submit" class="text-white py-2 px-4 rounded hover:bg-green-700"
+                        style="background-color: #335D43;">
+                        Save Changes
+                    </button>
+                </div>
+                <div>
+                    <button type="button" id="closeEditButton" class="bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400">
+                        Cancel
+                    </button>
+                </div>
+            </div>
         </form>
-        <button id="closeEditButton" class="mt-4 bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400">
-            Cancel
-        </button>
     </div>
 </div>
 
@@ -139,12 +195,23 @@
                 <button type="submit" class="bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700">
                     Delete
                 </button>
-                <button type="button" id="closeDeleteButton"
-                    class="bg-gray-600 text-white py-2 px-4 rounded hover:bg-gray-700">
+                <button type="button" id="closeDeleteButton" class="bg-gray-600 text-white py-2 px-4 rounded hover:bg-gray-700">
                     Cancel
                 </button>
             </div>
         </form>
+    </div>
+</div>
+
+<!-- Notes Popup -->
+<div id="notesPopup" class="hidden fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white p-6 rounded shadow-md w-full max-w-3xl flex flex-col">
+        <h3 class="text-xl font-bold mb-4">Notes of Crop</h3>
+        <textarea id="notesOfCropOutput" rows="30" disabled
+            class="w-full px-3 py-2 mb-4 overflow-y-auto border rounded resize-none"></textarea>
+        <button type="button" id="closeNotesButton" class="mt-4 bg-gray-300 text-gray-800 py-2 px-4 rounded hover:bg-gray-400">
+            Close
+        </button>
     </div>
 </div>
 
@@ -163,6 +230,7 @@
                 <th class="py-4 px-6 text-left text-sm font-medium text-gray-700 uppercase tracking-wider">Water Usage</th>
                 <th class="py-4 px-6 text-left text-sm font-medium text-gray-700 uppercase tracking-wider">Next Checkup</th>
                 <th class="py-4 px-6 text-left text-sm font-medium text-gray-700 uppercase tracking-wider">Region</th>
+                <th class="py-4 px-6 text-left text-sm font-medium text-gray-700 uppercase tracking-wider">Notes</th>
                 <th class="py-4 px-6 text-left text-sm font-medium text-gray-700 uppercase tracking-wider">Actions</th>
             </tr>
         </thead>
@@ -173,31 +241,46 @@
                 <td class="py-4 px-6 text-sm text-gray-900">{{ crop.name }}</td>
                 <td class="py-4 px-6 text-sm text-gray-900">{{ crop.crop_type }}</td>
                 <td class="py-4 px-6 text-sm text-gray-900">{{ crop.planting_date }}</td>
-                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.harvest_date|default:"-" }}</td>
-                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.expected_yield }}</td>
+                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.harvest_date|default:"—" }}</td>
+                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.expected_yield|default:"0" }}</td>
                 <td class="py-4 px-6 text-sm text-gray-900">{{ crop.yield_efficiency|default:"0" }}%</td>
                 <td class="py-4 px-6 text-sm text-gray-900">{{ crop.water_usage_liters|default:"0" }}L</td>
-                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.next_checkup|default:"-" }}</td>
-                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.region|default:"-" }}</td>
+                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.next_checkup|default:"—" }}</td>
+                <td class="py-4 px-6 text-sm text-gray-900">{{ crop.region|default:"—" }}</td>
+                <td class="py-4 px-6 text-sm">
+                    {% if crop.notes %}
+                    <button
+                        onclick="openNotesPopup('{{ crop.notes|escapejs }}')"
+                        class="text-white py-1 px-3 rounded text-sm hover:bg-amber-900"
+                        style="background-color: #b49494;">
+                        Open Notes
+                    </button>
+                    {% else %}
+                    —
+                    {% endif %}
+                </td>
                 <td class="py-4 px-6 text-sm">
                     <div class="flex space-x-2">
-                        <button onclick='openEditPopup(
+                        <button
+                            onclick='openEditPopup(
                                 "{{ crop.id }}",
                                 "{{ crop.name|escapejs }}",
                                 "{{ crop.crop_type|escapejs }}",
-                                "{{ crop.planting_date|date:'Y-m-d' }}",
-                                {% if crop.harvest_date %}"{{ crop.harvest_date|date:'Y-m-d' }}"{% else %}null{% endif %},
-                                "{{ crop.expected_yield }}",
+                                "{{ crop.planting_date|date:"Y-m-d" }}",
+                                {% if crop.harvest_date %}"{{ crop.harvest_date|date:"Y-m-d" }}"{% else %}null{% endif %},
+                                "{{ crop.expected_yield|default:"0" }}",
                                 "{{ crop.yield_efficiency|default:"0" }}",
                                 "{{ crop.water_usage_liters|default:"0" }}",
-                                {% if crop.next_checkup %}"{{ crop.next_checkup|date:'Y-m-d' }}"{% else %}null{% endif %},
+                                {% if crop.next_checkup %}"{{ crop.next_checkup|date:"Y-m-d" }}"{% else %}null{% endif %},
                                 "{{ crop.region|default:""|escapejs }}",
                                 "{{ crop.notes|default:""|escapejs }}"
-                            )' class="text-white py-1 px-3 rounded text-sm hover:bg-blue-700"
+                            )'
+                            class="text-white py-1 px-3 rounded text-sm hover:bg-blue-700"
                             style="background-color: #0D65A0;">
                             Edit
                         </button>
-                        <button onclick='openDeletePopup("{{ crop.id }}", "{{ crop.name|escapejs }}")'
+                        <button
+                            onclick='openDeletePopup("{{ crop.id }}", "{{ crop.name|escapejs }}")'
                             class="bg-red-600 text-white py-1 px-3 rounded text-sm hover:bg-red-700">
                             Delete
                         </button>
@@ -206,48 +289,45 @@
             </tr>
             {% empty %}
             <tr>
-                <td colspan="11" class="py-8 px-6 text-center text-gray-500">No crop records found</td>
+                <td colspan="12" class="py-8 px-6 text-center text-gray-500">No crop records found</td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
 </div>
 
-<!-- Pagination --->
+<!-- Pagination -->
 {% if crops.has_other_pages %}
 <div class="mt-6 flex justify-center">
     <nav class="flex items-center space-x-2">
         {% if crops.has_previous %}
-        <a href="?page={{ crops.previous_page_number }}" 
-           class="px-3 py-2 border rounded text-sm hover:bg-gray-100">
+        <a href="?page={{ crops.previous_page_number }}" class="px-3 py-2 border rounded text-sm hover:bg-gray-100">
             Previous
         </a>
         {% endif %}
-        
+
         {% for num in crops.paginator.page_range %}
             {% if crops.number == num %}
             <span class="px-3 py-2 border rounded text-sm bg-gray-200">{{ num }}</span>
             {% elif num > crops.number|add:'-3' and num < crops.number|add:'3' %}
-            <a href="?page={{ num }}" 
-               class="px-3 py-2 border rounded text-sm hover:bg-gray-100">
+            <a href="?page={{ num }}" class="px-3 py-2 border rounded text-sm hover:bg-gray-100">
                 {{ num }}
             </a>
             {% endif %}
         {% endfor %}
-        
+
         {% if crops.has_next %}
-        <a href="?page={{ crops.next_page_number }}" 
-           class="px-3 py-2 border rounded text-sm hover:bg-gray-100">
+        <a href="?page={{ crops.next_page_number }}" class="px-3 py-2 border rounded text-sm hover:bg-gray-100">
             Next
         </a>
         {% endif %}
-        
+
         <span class="text-sm text-gray-600 ml-4">
             Page {{ crops.number }} of {{ crops.paginator.num_pages }}
         </span>
     </nav>
 </div>
-{% endif %} 
+{% endif %}
 
 <script src="{% static 'js/crop_list.js' %}"></script>
 {% endblock %}

--- a/app/tests/crop/conftest.py
+++ b/app/tests/crop/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+from django.contrib.auth.models import User
+
+from app.backend.models import Crop
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user(client):
+    user = User.objects.create_user(username="tester", password="pass123")
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def crop():
+    return Crop.objects.create(
+        name="Corn",
+        crop_type="Grain",
+        planting_date="2026-02-25",
+        harvest_date="2027-01-21",
+        expected_yield=100,
+        yield_efficiency=80,
+        water_usage_liters=500,
+        next_checkup="2026-03-10",
+        region="Field A",
+        notes="Crop test note.\nCan have line break too. :)",
+    )
+
+
+@pytest.fixture
+def valid_crop_dict():
+    return {
+        "name": "Corn",
+        "crop_type": "Grain",
+        "planting_date": "2026-02-25",
+        "harvest_date": "2027-01-21",
+        "expected_yield": 100,
+        "yield_efficiency": 80,
+        "water_usage_liters": 500,
+        "next_checkup": "2026-03-10",
+        "region": "Field A",
+        "notes": "Crop test note.\nCan have line break too. :)",
+    }

--- a/app/tests/crop/test_add_view.py
+++ b/app/tests/crop/test_add_view.py
@@ -1,0 +1,113 @@
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_add_crop_success(client, user, mocker, valid_crop_dict):
+    mock_create = mocker.patch("app.backend.crop.crop.Crop.objects.create")
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(
+        reverse("add_crop"),
+        valid_crop_dict,
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")
+    mock_create.assert_called_once()
+    mock_logger.assert_any_call(
+        f"User {user} added crop: Corn (ID: {mock_create.return_value.id})"
+    )
+
+
+def test_add_crop_success_with_only_required_fields(client, user, mocker):
+    mock_create = mocker.patch("app.backend.crop.crop.Crop.objects.create")
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(
+        reverse("add_crop"),
+        {
+            "name": "Wheat",
+            "crop_type": "Cereal",
+            "planting_date": "2026-03-01",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")
+    mock_create.assert_called_once()
+    mock_logger.assert_any_call(
+        f"User {user} added crop: Wheat (ID: {mock_create.return_value.id})"
+    )
+
+
+def test_add_crop_missing_fields(client, user, mocker):
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+
+    response = client.post(reverse("add_crop"), {"name": ""})
+
+    assert response.status_code == 200
+    assert "error" in response.context
+    assert response.context["error"] == "Name, crop type, and planting date are required."
+    mock_logger.assert_any_call(
+        f"Crop creation error by {user}: Name, crop type, and planting date are required."
+    )
+    mock_all.assert_called_once()
+
+
+def test_add_crop_invalid_numeric_values(client, user, mocker, valid_crop_dict):
+    invalid_crop_dict = valid_crop_dict.copy()
+    invalid_crop_dict["expected_yield"] = "abc"
+
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+
+    response = client.post(reverse("add_crop"), invalid_crop_dict)
+
+    assert response.status_code == 200
+    assert "error" in response.context
+    assert "numeric fields" in response.context["error"].lower()
+    mock_logger.assert_called()
+    mock_all.assert_called_once()
+
+
+def test_add_crop_unexpected_exception(client, user, mocker, valid_crop_dict):
+    mocker.patch(
+        "app.backend.crop.crop.Crop.objects.create",
+        side_effect=Exception("DB Error"),
+    )
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(
+        reverse("add_crop"),
+        valid_crop_dict,
+    )
+
+    assert response.status_code == 200
+    assert "unexpected" in response.context["error"].lower()
+    mock_logger.assert_any_call("Unexpected error during crop creation: DB Error")
+    mock_all.assert_called_once()
+
+
+def test_add_crop_redirect_on_get(client, user):
+    response = client.get(reverse("add_crop"))
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")

--- a/app/tests/crop/test_delete_view.py
+++ b/app/tests/crop/test_delete_view.py
@@ -1,0 +1,66 @@
+import pytest
+from django.http import Http404
+from django.urls import reverse
+
+from app.backend.models import Crop
+
+pytestmark = pytest.mark.django_db
+
+
+def test_delete_crop_success(client, user, crop, mocker):
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    assert Crop.objects.count() == 1
+    response = client.post(reverse("delete_crop"), {"id": crop.id})
+
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")
+    assert Crop.objects.count() == 0
+    mock_logger.assert_any_call(f"User {user} deleted crop: {crop.name}")
+
+
+def test_delete_crop_not_found(client, user, mocker):
+    mocker.patch("app.backend.crop.crop.get_object_or_404", side_effect=Http404)
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(reverse("delete_crop"), {"id": 999})
+
+    assert response.status_code == 200
+    assert "error" in response.context
+    mock_logger.assert_called()
+    mock_all.assert_called_once()
+
+
+def test_delete_crop_unexpected_exception(client, user, mocker):
+    mocker.patch(
+        "app.backend.crop.crop.get_object_or_404",
+        side_effect=Exception("Unexpected fail"),
+    )
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(reverse("delete_crop"), {"id": 1})
+
+    assert response.status_code == 200
+    assert "unexpected" in response.context["error"].lower()
+    mock_logger.assert_any_call(
+        "Unexpected error during crop deletion: Unexpected fail"
+    )
+    mock_all.assert_called_once()
+
+
+def test_delete_crop_redirect_on_get(client, user):
+    response = client.get(reverse("delete_crop"))
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")

--- a/app/tests/crop/test_edit_view.py
+++ b/app/tests/crop/test_edit_view.py
@@ -1,0 +1,124 @@
+import pytest
+from django.http import Http404
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_edit_crop_success(client, user, crop, mocker):
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(
+        reverse("edit_crop"),
+        {
+            "id": crop.id,
+            "name": "Updated Corn",
+            "crop_type": "Updated Grain",
+            "planting_date": "2026-02-26",
+            "harvest_date": "2027-01-25",
+            "expected_yield": 120,
+            "yield_efficiency": 85,
+            "water_usage_liters": 600,
+            "next_checkup": "2026-03-15",
+            "region": "Field B",
+            "notes": "Updated crop note.",
+        },
+    )
+
+    crop.refresh_from_db()
+    assert crop.name == "Updated Corn"
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")
+    mock_logger.assert_any_call(f"User {user} edited crop: Corn to Updated Corn")
+
+
+def test_edit_crop_missing_fields(client, user, crop, mocker):
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(
+        reverse("edit_crop"),
+        {
+            "id": crop.id,
+            "name": "",
+            "crop_type": "",
+            "planting_date": "",
+            "expected_yield": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "error" in response.context
+    assert response.context["error"] == "Name, crop type, and planting date are required."
+    mock_logger.assert_any_call(
+        f"Crop edit error by {user}: Name, crop type, and planting date are required."
+    )
+
+
+def test_edit_crop_invalid_numeric_values(client, user, crop, mocker):
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(
+        reverse("edit_crop"),
+        {
+            "id": crop.id,
+            "name": "Corn",
+            "crop_type": "Grain",
+            "planting_date": "2026-02-25",
+            "expected_yield": "abc",
+            "yield_efficiency": "xyz",
+            "water_usage_liters": "bad",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "error" in response.context
+    assert "invalid numeric values" in response.context["error"].lower()
+    mock_logger.assert_any_call(
+        f"Crop edit error by {user}: Invalid numeric values in yield or water usage fields."
+    )
+
+
+def test_edit_crop_not_found(client, user, mocker):
+    mocker.patch("app.backend.crop.crop.get_object_or_404", side_effect=Http404)
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(reverse("edit_crop"), {"id": 999})
+
+    assert response.status_code == 200
+    assert "error" in response.context
+    mock_logger.assert_called()
+    mock_all.assert_called_once()
+
+
+def test_edit_crop_unexpected_exception(client, user, mocker):
+    mock_get = mocker.patch(
+        "app.backend.crop.crop.get_object_or_404",
+        side_effect=Exception("Something broke"),
+    )
+
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = []
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.post(reverse("edit_crop"), {"id": 1})
+
+    assert response.status_code == 200
+    assert "unexpected" in response.context["error"].lower()
+    mock_get.assert_called_once()
+    mock_logger.assert_any_call("Unexpected error during crop edit: Something broke")
+    mock_all.assert_called_once()
+
+
+def test_edit_crop_redirect_on_get(client, user):
+    response = client.get(reverse("edit_crop"))
+    assert response.status_code == 302
+    assert response.url == reverse("crop_list")

--- a/app/tests/crop/test_list_view.py
+++ b/app/tests/crop/test_list_view.py
@@ -1,0 +1,41 @@
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_crop_list_renders_all(client, user, mocker):
+    mock_crops = [
+        mocker.MagicMock(name="crop1"),
+        mocker.MagicMock(name="crop2"),
+    ]
+    mock_queryset = mocker.MagicMock()
+    mock_queryset.order_by.return_value = mock_crops
+
+    mock_all = mocker.patch(
+        "app.backend.crop.crop.Crop.objects.all", return_value=mock_queryset
+    )
+    mock_logger = mocker.patch("app.backend.crop.crop.logger.log")
+
+    response = client.get(reverse("crop_list"))
+
+    assert response.status_code == 200
+    assert "crops" in response.context
+    mock_all.assert_called_once()
+    mock_logger.assert_called_once_with(f"User {user} viewed crop list (page 1).")
+
+
+def test_crop_list_contains_notes_column(client, user, crop):
+    response = client.get(reverse("crop_list"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Notes" in content
+
+
+def test_crop_list_shows_open_notes_when_notes_exist(client, user, crop):
+    response = client.get(reverse("crop_list"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Open Notes" in content


### PR DESCRIPTION
This PR implements the crop modal UI and aligns crop functionality with the existing supplies pattern.

Changes included:
- Added modal form for creating crops
- Implemented notes popup in crop list
- Updated crop add/edit/delete views with validation handling
- Ensured required fields: name, crop type, and planting date
- Handled numeric fields safely with error handling
- Added full pytest coverage for crop views

Tests added:
- add crop (success, missing fields, invalid numeric values, unexpected exception)
- edit crop (success, missing fields, invalid numeric values, exceptions)
- delete crop (success, not found, unexpected exception)
- list view (renders crops, notes column, notes popup)

Result:
- 19 crop tests passing locally
- No changes made to unrelated modules